### PR TITLE
Enhance interview assistant with Supabase logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# CrackIT Interview Assistant
+
+This project is a React and TypeScript application that provides a live interview assistant. It transcribes spoken questions, generates AI powered answers and can join video meetings.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Copy `.env.example` to `.env` and fill in your API keys.
+
+3. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Features
+
+- Speech recognition for capturing questions
+- Streaming AI responses using the OpenRouter API
+- Video meeting integration via Jitsi or Zoom
+- Optional Supabase integration for storing transcripts
+

--- a/project/.env.example
+++ b/project/.env.example
@@ -1,0 +1,5 @@
+VITE_OPENROUTER_API_KEY=your-openrouter-api-key
+VITE_ZOOM_SDK_KEY=your-zoom-sdk-key
+VITE_ZOOM_SDK_SECRET=your-zoom-sdk-secret
+VITE_SUPABASE_URL=your-supabase-url
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key

--- a/project/src/lib/database.ts
+++ b/project/src/lib/database.ts
@@ -1,0 +1,37 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+export interface DBMessage {
+  type: 'question' | 'answer';
+  text: string;
+  timestamp: Date;
+}
+
+export class DatabaseService {
+  private client: SupabaseClient | null = null;
+
+  constructor() {
+    const url = import.meta.env.VITE_SUPABASE_URL;
+    const key = import.meta.env.VITE_SUPABASE_ANON_KEY;
+    if (url && key) {
+      this.client = createClient(url, key);
+    } else {
+      console.warn('Supabase environment variables are not configured');
+    }
+  }
+
+  async saveMessage(message: DBMessage): Promise<void> {
+    if (!this.client) return;
+    try {
+      const { error } = await this.client.from('messages').insert({
+        type: message.type,
+        text: message.text,
+        timestamp: message.timestamp.toISOString(),
+      });
+      if (error) {
+        console.error('Failed to save message', error);
+      }
+    } catch (err) {
+      console.error('Unexpected error saving message', err);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add Supabase database service for saving transcripts
- log questions and answers from the assistant widgets
- provide environment variable examples
- add basic project README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867a988e8ac83248740825370223fa8